### PR TITLE
add support for WP Multisite

### DIFF
--- a/src/WpGlide.php
+++ b/src/WpGlide.php
@@ -192,7 +192,7 @@ class WpGlide
 
         $relativeUrl = $this->baseUrl . "{$slug}/" . $this->relativeUploadUrl($url);
 
-        return self::removeUrlProtocol(site_url($relativeUrl));
+        return self::removeUrlProtocol(network_site_url($relativeUrl));
     }
 
     /**
@@ -310,6 +310,10 @@ class WpGlide
     public function relativeUploadUrl(string $url)
     {
         $uploadsBaseUrl = wp_upload_dir()['baseurl'];
+
+        if (is_multisite()) {
+            $uploadsBaseUrl = rtrim(str_replace('/sites/'.get_current_blog_id(), '', $uploadsBaseUrl), '/');
+        }
 
         return ltrim(str_replace($uploadsBaseUrl, '', $url), '/');
     }


### PR DESCRIPTION
using `network_site_url()` function instead of `site_url()` will give us the url even if the website is not a network.

Source 
https://codex.wordpress.org/Function_Reference/network_site_url
`If the site is not setup as multisite, site_url() will be used instead.`

fix relative path since MU has other structures.